### PR TITLE
Set uriOrEmpty from oneOf to anyOf for compatibility with validators that do not implement format uri

### DIFF
--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -15,7 +15,7 @@
 		"uriOrEmpty": {
 			"type": "string",
 			"maxLength": 1000,
-			"oneOf": [
+			"anyOf": [
 				{ "format": "uri" },
 				{ "maxLength": 0 }
 			],

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -1,4 +1,4 @@
-# Flywheel Gear Spec (v0.1.1)
+# Flywheel Gear Spec (v0.1.2)
 
 This document describes the structure of a Flywheel Gear.
 


### PR DESCRIPTION
From the spec:

> JSON Schema implementations are not required to implement this part of the specification, and many of them do not.

If a validator does not implement `"format": "uri"`, validation will fail because `oneOf` will be matched by both clauses. This changes it for `anyOf`, which will have no effect on complete parsers and be compatible with incomplete ones.

----

Is this a semantic or operational change? If so:

* [x] Increment the version in spec/readme.md
* [x] After merge, tag the version and update the release page
