### PR TITLE
Spec improvements: custom environment variables, command templating, non-scalar config values, job-bounded API keys

### DIFF
--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -50,6 +50,15 @@
 			"maxLength": 5000,
 			"description": "A brief description of the gear's purpose. Ideally 1-4 sentances."
 		},
+		"environment": {
+			"type": "object",
+			"additionalProperties": { "type": "string" },
+			"description": "Environment variables that should be set for the gear."
+		},
+		"command": {
+			"type": "string",
+			"description": "If provided, the starting command for the gear, rather than /flywheel/v0/run. Will be templated according to the spec."
+		},
 		"inputs": {
 			"type": "object",
 			"additionalProperties": {
@@ -57,8 +66,8 @@
 				"properties": {
 					"base": {
 						"type": "string",
-						"enum": [ "file" ],
-						"description": "The type of gear input. Currently only supports a file."
+						"enum": [ "file", "api-key" ],
+						"description": "The type of gear input."
 					},
 					"description": {
 						"type": "string",

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -64,7 +64,7 @@ Note, the `// comments` shown below are not JSON syntax and cannot be included i
 	},
 
 	// (Optional) Command to execute. Ran inside a bash shell.
-	"environment": "python script.py"
+	"command": "python script.py"
 
 	// Options that the gear can use
 	"config": {


### PR DESCRIPTION
Starting point. Needs docs on api-key interaction, how the templating works, config --> environment variables, and some other stuff.

----

Is this a semantic or operational change? If so:

* [ ] Increment the version in spec/readme.md
* [ ] After merge, tag the version and update the release page
