### PR TITLE
Add a cite field

### DIFF
--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -34,6 +34,11 @@
 			"maxLength": 100,
 			"description": "(optional) The maintainer of this gear. Can be used to distinguish the algorithm author from the gear maintainer."
 		},
+		"cite": {
+			"type": "string",
+			"maxLength": 5000,
+			"description": "(optional) Any citations relevant to the algorithm(s) or work present in the gear."
+		},
 		"config": {
 			"type": "object",
 			"additionalProperties": {

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -1,4 +1,4 @@
-# Flywheel Gear Spec (v0.1.3)
+# Flywheel Gear Spec (v0.1.4)
 
 This document describes the structure of a Flywheel Gear.
 
@@ -48,6 +48,9 @@ Note, the `// comments` shown below are not JSON syntax and cannot be included i
 	// (Optional) the maintainer, which may be distinct from the algorithm author.
 	// Can be the same as the author field if both roles were filled by the same individual.
 	"maintainer":  "Nathaniel Kofalt",
+
+	// (Optional) Any citations you wish to add.
+	"cite":  "",
 
 	// Must be an OSI-approved SPDX license string or 'Other'. Ref: https://spdx.org/licenses
 	"license": "Apache-2.0",


### PR DESCRIPTION
Based on an out-of-band request to display citation information of a gear.

----

Is this a semantic or operational change? If so:

* [x] Increment the version in spec/readme.md
* [ ] After merge, tag the version and update the release page
