### PR TITLE
Document the current bash requirement

### DIFF
--- a/spec/readme.md
+++ b/spec/readme.md
@@ -8,6 +8,10 @@ A Flywheel gear is a tar file (.tar) of a container; the container must include 
 
 This tar file can be created from most common container tools (e.g., Docker).
 
+#### Minimum container requirements
+
+The only requirement for the underlying container is that it must be a \*nix system that provides a bash shell on the path.
+
 ## The base folder
 
 To be a Flywheel gear, the container in the tar file must include a folder named: `/flywheel/v0`.


### PR DESCRIPTION
Added an explicit clarification of the minimum container requirements for the current version of the spec. Ultimately we'd like to look into removing the bash requirement in a future version.

----

Is this a semantic or operational change? **NO** If so:

* [ ] Increment the version in spec/readme.md
* [ ] After merge, tag the version and update the release page

Refs #21 
@kofalt @gsfr 

