### PR TITLE
Add CI target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+
+jobs:
+    build:
+        working_directory: "~/gears"
+
+        docker:
+            - image: python:2-alpine3.7
+
+        steps:
+            - checkout
+
+            - restore_cache:
+                key: gears-1-{{ checksum "setup.py"}}
+
+            - run:
+                name: Install Dependencies
+                command: pip install -e .
+
+            - save_cache:
+                key: gears-1-{{ checksum "setup.py"}}
+                paths:
+                    - "~/.cache/pip"
+
+            - run:
+                name: Validate
+                command: python validate.py

--- a/gears/generator.py
+++ b/gears/generator.py
@@ -165,11 +165,3 @@ def validate_invocation(manifest, invocation):
 
 	inv_schema = derive_invocation_schema(manifest)
 	jsonschema.validate(invocation, inv_schema)
-
-
-def test(): # Can become a test case later :)
-	x = load_json_from_file(os.path.join(get_project_dir(), "manifest.example.json"))
-	validate_manifest(x)
-
-	y = load_json_from_file(os.path.join(get_project_dir(), "invocation.example.json"))
-	validate_invocation(x, y)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 ## Flywheel Gears
 
+[![Build status](https://circleci.com/gh/flywheel-io/gears/tree/master.svg?style=shield&circle-token=fa0c0bf6fa27a8548231fc12baff5f633ae201d8)](https://circleci.com/gh/flywheel-io/gears)
+
 This repository holds the [gear specification](spec) as well as a Python library of [gear-related tools](gears).
 
 #### Example Gear

--- a/validate.py
+++ b/validate.py
@@ -1,0 +1,7 @@
+import gears
+
+x = gears.load_json_from_file("gears/manifest.example.json")
+gears.validate_manifest(x)
+
+y = gears.load_json_from_file("gears/invocation.example.json")
+gears.validate_invocation(x, y)


### PR DESCRIPTION
Because why not. This simple target ensures that:

1. The module is roughly valid python
1. The manifest schema is correct
1. Our example manifest and invocation validate