### PR TITLE
Gear capabilities

### DIFF
--- a/gears/manifest.example.json
+++ b/gears/manifest.example.json
@@ -20,5 +20,8 @@
 			"type": { "enum": [ "dicom" ] }
 
 		}
-	}
+	},
+	"capabilities": [
+		"networking"
+	]
 }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,9 @@
 ## Flywheel Gears
 
-[![Build status](https://circleci.com/gh/flywheel-io/gears/tree/master.svg?style=shield&circle-token=fa0c0bf6fa27a8548231fc12baff5f633ae201d8)](https://circleci.com/gh/flywheel-io/gears)
+[![Build status](https://circleci.com/gh/flywheel-io/gears/tree/master.svg?style=shield)](https://circleci.com/gh/flywheel-io/gears)
 
 This repository holds the [gear specification](spec) as well as a Python library of [gear-related tools](gears).
 
 #### Example Gear
+
 The example gear previously located here has been moved to a [separate repository](https://github.com/flywheel-apps/example-gear).

--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -90,6 +90,13 @@
 			},
 			"description": "Schema snippets describing the inputs this gear consumes."
 		},
+		"capabilities": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"description": "A set of features the gear requires to run (for example, networking)."
+		},
 		"label": {
 			"type": "string",
 			"maxLength": 100,

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -1,4 +1,4 @@
-# Flywheel Gear Spec (v0.1.4)
+# Flywheel Gear Spec (v0.1.5)
 
 This document describes the structure of a Flywheel Gear.
 
@@ -117,7 +117,12 @@ Note, the `// comments` shown below are not JSON syntax and cannot be included i
 
 			"description": "Any dicom file."
 		}
-	}
+	},
+
+	// Capabilities the gear requires. Not necessary unless you need a specific feature.
+	"capabilities": [
+		"networking"
+	],
 }
 ```
 
@@ -244,13 +249,27 @@ Any required environment and path variables should be specified within the scrip
 
 The file is also executed with no arguments. You must specify the inputs to the executables in the `run` script, such as the input file names or flags.
 
+### Capabilities
+
+Capabilities allow for a gear to require certain environmental feature support.
+
+Currently, the only capability available is `networking`, which requires basic outbound networking as described below.
+In the future, there will likely be more added: `cuda`, `hpc`, etc.
+
+Do not add speculative capabilities to your manifest.
+Executors that do not recognize or cannot provide a specified capability are forbidden from launching the job.
+
 ### Networking
 
-At the current time, basic outbound networking may be available to the gear. This is not necessarily guaranteed, and may vary depending on your installation's setup. It is likely that this feature will become opt-in in a future version of the spec.
+Some gears may require outbound networking (to contact the Flywheel API, or for some other purpose).
+If your gear needs this, please add the `networking` capability to your manifest as shown in the example above.
+
+For now, all gears are provided some networking, but this is not guaranteed, and may vary depending on your installation's setup.
+Adding the capability will future-proof your gear as it is likely this will be changed in the future.
 
 Be sure to get in touch with us regarding your networking needs - Matlab license checks, for example.
 
-There are no current plans to allow inbound networking.
+There are no plans to allow inbound networking.
 
 ## Contact
 


### PR DESCRIPTION
Gear capabilities are specific, custom environmental features required for the gear to execute. Such capabilities may eventually include features such as `hpc`, `cuda`, various licensing, or etc. The contract is such that a gear executor must have a superset of the gear's capabilities to run the job.

The first specified capability is `networking`. Right now, outbound networking is implicitly (incidentally) always provided, and this does not change that, but it lays the groundwork to tighten the belt later and make outbound networking explicitly opt-in. That is a breaking change that we can handle & communicate separately.

I'm bumping the version as shown below, but I don't think we should tag & release yet. Let's group a few small related changes together, since they'll be tightly spaced.

----

Is this a semantic or operational change? If so:

* [ ] Increment the version in spec/readme.md
* [ ] After merge, tag the version and update the release page
