### PR TITLE
Read-only API keys, stricter schema typing, and more examples

### DIFF
--- a/examples/valid-api-key-ro/manifest.json
+++ b/examples/valid-api-key-ro/manifest.json
@@ -8,23 +8,11 @@
 	"url":     "http://example.com",
 	"source":  "http://example.com/code",
 	"config": {
-		"speed": {
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 3
-		}
 	},
 	"inputs": {
-		"dicom": {
-			"base": "file",
-			"type": { "enum": [ "dicom" ] }
-
-		},
-		"matlab_license_code": {
-			"base": "context"
-		},
-		"sdk": {
-			"base": "api-key"
+		"key": {
+			"base": "api-key",
+			"read-only": true
 		}
 	},
 	"capabilities": [

--- a/examples/valid-api-key-ro/readme.md
+++ b/examples/valid-api-key-ro/readme.md
@@ -1,0 +1,3 @@
+# API Key example (read-only)
+
+This gear takes an API key as an input, which is only allowed to perform read actions.

--- a/examples/valid-api-key/manifest.json
+++ b/examples/valid-api-key/manifest.json
@@ -8,22 +8,9 @@
 	"url":     "http://example.com",
 	"source":  "http://example.com/code",
 	"config": {
-		"speed": {
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 3
-		}
 	},
 	"inputs": {
-		"dicom": {
-			"base": "file",
-			"type": { "enum": [ "dicom" ] }
-
-		},
-		"matlab_license_code": {
-			"base": "context"
-		},
-		"sdk": {
+		"key": {
 			"base": "api-key"
 		}
 	},

--- a/examples/valid-api-key/readme.md
+++ b/examples/valid-api-key/readme.md
@@ -1,0 +1,3 @@
+# API Key example
+
+This gear takes an API key as an input.

--- a/examples/valid-context/manifest.json
+++ b/examples/valid-context/manifest.json
@@ -8,23 +8,10 @@
 	"url":     "http://example.com",
 	"source":  "http://example.com/code",
 	"config": {
-		"speed": {
-			"type": "integer",
-			"minimum": 0,
-			"maximum": 3
-		}
 	},
 	"inputs": {
-		"dicom": {
-			"base": "file",
-			"type": { "enum": [ "dicom" ] }
-
-		},
-		"matlab_license_code": {
+		"license_key": {
 			"base": "context"
-		},
-		"sdk": {
-			"base": "api-key"
 		}
 	},
 	"capabilities": [

--- a/examples/valid-context/readme.md
+++ b/examples/valid-context/readme.md
@@ -1,0 +1,3 @@
+# Context value example
+
+This gear takes a context value as an input.

--- a/examples/valid-simple/invocation.json
+++ b/examples/valid-simple/invocation.json
@@ -10,6 +10,10 @@
 			"base": "context",
 			"found": true,
 			"value": "ABC"
+		},
+		"sdk": {
+			"base": "api-key",
+			"key": "aex"
 		}
 	}
 }

--- a/examples/valid-simple/readme.md
+++ b/examples/valid-simple/readme.md
@@ -1,3 +1,3 @@
 # Simple example
 
-This is almost the simplest manifest possible, with one config value and one input.
+This is a simplest manifest example, with one config value and a few inputs.

--- a/examples/valid-simple/readme.md
+++ b/examples/valid-simple/readme.md
@@ -1,3 +1,3 @@
 # Simple example
 
-This is a simplest manifest example, with one config value and a few inputs.
+This is a simple manifest example, with one config value and a few inputs.

--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -118,9 +118,7 @@
 							}
 						},
 						"required": ["base"],
-						"additionalProperties": {
-							"$ref": "#/definitions/directive"
-						},
+						"additionalProperties": false,
 
 						"description": "A contextual input, retrieved from the environment on launch."
 					},

--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -71,32 +71,88 @@
 			"type": "string",
 			"description": "If provided, the starting command for the gear, rather than /flywheel/v0/run. Will be templated according to the spec."
 		},
+
 		"inputs": {
 			"type": "object",
+
 			"additionalProperties": {
-				"type": "object",
-				"properties": {
-					"base": {
-						"type": "string",
-						"enum": [ "file", "api-key", "context" ],
-						"description": "The type of gear input."
+				"anyOf": [
+
+					{
+						"type": "object",
+						"properties": {
+							"base": {
+								"type": "string",
+								"enum": [ "file" ],
+								"description": "The type of gear input."
+							},
+							"description": {
+								"type": "string",
+								"description": "Hackaround for description not technically being a schema directive"
+							},
+							"optional": {
+								"type": "boolean",
+								"description": "Allow the gear to mark an input file as optional."
+							}
+						},
+						"required": ["base"],
+						"additionalProperties": {
+							"$ref": "#/definitions/directive"
+						},
+
+						"description": "A file input, optionally using schema snippets to further refine the type of file taken."
 					},
-					"description": {
-						"type": "string",
-						"description": "Hackaround for description not technically being a schema directive"
+
+					{
+
+						"type": "object",
+						"properties": {
+							"base": {
+								"type": "string",
+								"enum": [ "context" ],
+								"description": "The type of gear input."
+							},
+							"description": {
+								"type": "string",
+								"description": "Hackaround for description not technically being a schema directive"
+							}
+						},
+						"required": ["base"],
+						"additionalProperties": {
+							"$ref": "#/definitions/directive"
+						},
+
+						"description": "A contextual input, retrieved from the environment on launch."
 					},
-					"optional": {
-						"type": "boolean",
-						"description": "Allow the gear to mark an input file as optional."
+
+					{
+						"type": "object",
+						"properties": {
+							"base": {
+								"type": "string",
+								"enum": [ "api-key" ],
+								"description": "The type of gear input."
+							},
+							"description": {
+								"type": "string",
+								"description": "Hackaround for description not technically being a schema directive"
+							},
+							"read-only": {
+								"type": "boolean",
+								"description": "Requests that the provisioned API key be only allowed read access."
+							}
+						},
+						"required": ["base"],
+						"additionalProperties": false,
+
+						"description": "An api-key input for accessing data with an SDK."
 					}
-				},
-				"required": ["base"],
-				"additionalProperties": {
-					"$ref": "#/definitions/directive"
-				}
+				]
 			},
+
 			"description": "Schema snippets describing the inputs this gear consumes."
 		},
+
 		"capabilities": {
 			"type": "array",
 			"items": {

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -178,7 +178,7 @@ It is possible to interact with the Flywheel data hierarchy using our [python](h
 
 Generally, you will want to figure out a script that you like, using your normal user API key, before turning it into a gear. To do this, specify an `api-key` type input as show in the example above, and use that value in your gear script.
 
-The key provided will be a special key that has the same access as the running user (not necessarily the gear author), and only work while the job is running. After the job completes, the key is retired.
+The key provided will be a special key that has the same access as the running user (not necessarily the gear author), and only work while the job is running. After the job completes, the key is retired. This has write access by default, but you can make it read only by adding `"read-only": true` to the manifest as shown above.
 
 ### The input folder
 

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -1,4 +1,4 @@
-# Flywheel Gear Spec (v0.1.6)
+# Flywheel Gear Spec (v0.1.7)
 
 This document describes the structure of a Flywheel Gear.
 
@@ -123,6 +123,15 @@ Note, the `// comments` shown below are not JSON syntax and cannot be included i
 		"matlab_license_code": {
 			"base": "context",
 		},
+
+		// An API key, specific to this job, with the same access as the user that launched the gear.
+		// Useful for aggregations, integrating with an external system, data analysis, or other automated tasks.
+		"key": {
+			"base": "api-key",
+
+			// (Optional) request that the API key only be allowed read access.
+			"read-only": true
+		}
 	},
 
 	// Capabilities the gear requires. Not necessary unless you need a specific feature.
@@ -161,6 +170,15 @@ It is up to the gear executor to decide how (and if) context is provided. In the
 Unlike a gear's config values, contexts are not guaranteed to exist _or_ have a specific type or format. It is up to the gear to decide if it can continue, or exit with an error, when a context value does not match what the gear expects. In the example config file below, note that the `found` key can be checked to determine if a value was provided by the environment.
 
 Because context values are not namespaced, it is suggested that you use a specific and descriptive name. The `matlab_license_code` example is a good, self-explanatory key that many gears could likely reuse.
+
+
+### API keys
+
+It is possible to interact with the Flywheel data hierarchy using our [python](https://flywheel-io.github.io/core/branches/master/python/getting_started.html), [matlab](https://flywheel-io.github.io/core/branches/master/matlab/getting_started.html), and (slated for an overhaul) [golang](https://github.com/flywheel-io/sdk) SDKs.
+
+Generally, you will want to figure out a script that you like, using your normal user API key, before turning it into a gear. To do this, specify an `api-key` type input as show in the example above, and use that value in your gear script.
+
+The key provided will be a special key that has the same access as the running user (not necessarily the gear author), and only work while the job is running. After the job completes, the key is retired.
 
 ### The input folder
 


### PR DESCRIPTION
Until now, the schema combined all gear input types. This allowed schema directives to be added to input types that would be ignored (context, api-key).

This PR fixes that while also adding a read-only specifier to the api-key type, provides some more bona-fide validation tests, and adds missing documentation about the api-key input. Notably absent are invalid examples, which we should add at some point.


----

Is this a semantic or operational change? If so:

* [x] Increment the version in spec/readme.md
* [x] After merge, tag the version and update the release page
