### PR TITLE
Add litmus test based on the flywheel exchange

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,5 +23,9 @@ jobs:
               - "~/.cache/pip"
 
       - run:
-          name: Validate
-          command: examples/test.py
+          name: Validation suite
+          command: examples/test.py validation
+
+      - run:
+          name: Exchange litmus test
+          command: .circleci/litmus-test.sh

--- a/.circleci/litmus-test.sh
+++ b/.circleci/litmus-test.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 set -x
 
-pwd
-
 # Working directory
 rm -rf temp; mkdir -p temp; cd temp
 
@@ -22,3 +20,5 @@ find $folder/ -type f -name '*.json' | wc -l
 # Run test
 ../examples/test.py custom ./$folder
 
+# Cleanup
+cd ..; rm -rf temp

--- a/.circleci/litmus-test.sh
+++ b/.circleci/litmus-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -euo pipefail
+set -x
+
+pwd
+
+# Working directory
+rm -rf temp; mkdir -p temp; cd temp
+
+# All manifests that have been archived
+wget https://github.com/flywheel-io/exchange/archive/master.tar.gz
+
+# Set to "manifests" for every version of every gear (needs modification), or "gears" for latest only.
+folder="gears"
+
+# Expand just the manifests
+tar -xf master.tar.gz --strip-components 1 exchange-master/$folder
+
+# Count
+find $folder/ -type f -name '*.json' | wc -l
+
+# Run test
+../examples/test.py custom ./$folder
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .*sw[op]
 *.py[co]
 *.egg-info
+
+/.circleci/temp

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-from os import sys, path, listdir
+import argparse
+from os import sys, path, listdir, walk
+import fnmatch
 import sys
 import jsonschema
 
@@ -10,19 +12,26 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 import gears
 
 def header(name):
+	"""
+	Generate a report header, in the vein of common system utilities
+	"""
+
 	sys.stdout.write('Testing ' + name + '...')
 
 	spacing = 80 - 8 - 3 -3 - len(name)
 	if spacing > 0:
 		sys.stdout.write(' ' * spacing)
 
+	# Allows one to observe progress on longer test runs
 	sys.stdout.flush()
 
-def test(name, folder):
-	header(name)
+def run_test(name, manifest, invocation=None):
+	"""
+	Run a test with a given name, manifest, and optionally invocation.
+	Throws on failure.
+	"""
 
-	manifest = path.join(folder, 'manifest.json')
-	invocation = path.join(folder, 'invocation.json')
+	header(name)
 
 	if path.isfile(manifest):
 		x = gears.load_json_from_file(manifest)
@@ -30,15 +39,17 @@ def test(name, folder):
 	else:
 		raise Exception("Test has no manifest: " + name)
 
-	if path.isfile(invocation):
+	if invocation is not None and path.isfile(invocation):
 		y = gears.load_json_from_file(invocation)
 		gears.validate_invocation(x, y)
 
-def test_wrap(name, folder, shouldpass):
-	e = None
+def run_test_wrap(name, manifest, invocation, shouldpass):
+	"""
+	Executes run_test in a try/catch, printing a footer with the result.
+	"""
 
 	try:
-		test(name, folder)
+		run_test(name, manifest, invocation)
 		if shouldpass:
 			print '[X]'
 			return
@@ -55,7 +66,11 @@ def test_wrap(name, folder, shouldpass):
 	print '[ ]'
 	raise Exception('Test should fail but did not: ' + name)
 
-def test_folders():
+def run_validation_suite(args):
+	"""
+	Test the generator against each example in the validation suite.
+	"""
+
 	base = path.dirname(path.abspath(__file__))
 
 	for f in listdir(base):
@@ -63,15 +78,54 @@ def test_folders():
 		name = f.replace('invalid-', '').replace('valid-', '')
 
 		if path.isdir(file):
+
+			manifest = path.join(file, 'manifest.json')
+			invocation = path.join(file, 'invocation.json')
+
 			if f.startswith('valid-'):
-				test_wrap(name, file, True)
+				run_test_wrap(name, manifest, invocation, True)
 			elif f.startswith('invalid-'):
-				test_wrap(name, file, False)
+				run_test_wrap(name, manifest, invocation, False)
 			else:
 				raise Exception('Folder is improperly named: ' + f)
 
+def run_custom_suite(args):
+	"""
+	Test the generator against each example in the custom folder.
+	All JSON files are assumed to be valid.
+	"""
+
+	base = args.path
+
+	for root, dirnames, filenames in walk(base):
+		for filename in fnmatch.filter(filenames, '*.json'):
+
+			manifest = path.join(root, filename)
+			run_test_wrap(filename, manifest, None, True)
+
+def generate_cli():
+	"""
+	Generate a simplistic command-line interface.
+	"""
+
+	parser = argparse.ArgumentParser()
+	commands = parser.add_subparsers()
+
+	validation = commands.add_parser('validation')
+	validation.set_defaults(func=run_validation_suite)
+
+	custom = commands.add_parser('custom')
+	custom.set_defaults(func=run_custom_suite)
+	custom.add_argument('path')
+
+	return parser
+
+
 def main():
-	test_folders()
+	parser = generate_cli()
+	args = parser.parse_args()
+
+	args.func(args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Adds a variant to the test script, that checks all the latest gears in the exchange.

On general principles, if something there fails to validate, there is probably a bug in either the exchange, or, more likely, an in-development schema change.

Example:

```
Testing bxh-xcede-tools-qa.json...                                           [X]
Testing mri-deface.json...                                                   [X]
Testing fmriprep.json...                                                     [X]
Testing extract-cmrr-physio.json...                                          [X]
Testing hcp-diff.json...                                                     [X]
Testing fsl-fslhd.json...                                                    [X]
Testing sti-qsm-demo.json...                                                 [X]
Testing eeg-classifier.json...                                               [X]
Testing hcp-struct.json...                                                   [X]
...
````