### PR TITLE
Separate out api-key type inputs in gears.derive_invocation_schema

### DIFF
--- a/gears/generator.py
+++ b/gears/generator.py
@@ -106,11 +106,19 @@ def derive_invocation_schema(manifest):
 				keyType = manifest[kind][key]['base']
 				spec = {}
 
-				if keyType == 'file' or keyType == 'api-key':
-					# Object with any particular properties (could be refined further)
+				if keyType == 'file':
+					# Object with any particular properties suggested from the manifest
+					# Does not validate the upstream file object schema; that is left to other tools.
 					spec = {
 						'type': 'object',
 						'properties': value, # copy over schema snippet from manifest
+					}
+
+				elif keyType == 'api-key':
+					# There is currently only an implicit declaration of how api-key type inputs are provisioned.
+					# For now, declare an object. Should be improved later.
+					spec = {
+						'type': 'object'
 					}
 
 				elif keyType == 'context':

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -1,4 +1,4 @@
-# Flywheel Gear Spec (v0.1.7)
+# Flywheel Gear Spec (v0.1.8)
 
 This document describes the structure of a Flywheel Gear.
 


### PR DESCRIPTION
Bugfix for gears with a read-only API key. Root cause is the lack of a declarative transformation between what's requested (manifest) and what's provided (config.json).

----

Is this a semantic or operational change? If so:

* [x] Increment the version in spec/readme.md
* [ ] After merge, tag the version and update the release page
