### PR TITLE
Remove duplicate capabilities field from schema

### DIFF
--- a/spec/manifest.schema.json
+++ b/spec/manifest.schema.json
@@ -163,12 +163,6 @@
 			"maxLength": 100,
 			"description": "The human-friendly name of this gear."
 		},
-		"capabilities": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
 		"license": {
 			"type": "string",
 			"enum": [


### PR DESCRIPTION
The schema was still valid, but there's no reason to override.